### PR TITLE
Updates Redux course slice of state with missing modules property

### DIFF
--- a/src/state/ducks/coursesDuck.js
+++ b/src/state/ducks/coursesDuck.js
@@ -146,6 +146,7 @@ const coursesInitialState = {
     courseCode: '',
     courseDescription: '',
     program: {},
+    modules: [],
   },
 };
 


### PR DESCRIPTION
Modules were not displaying on the Course View Component. There was a missing slice of state in the coursesDuck so modules were never being saved to global state. This fixes the issue!